### PR TITLE
refactor: unify resi code handling

### DIFF
--- a/app/Http/Controllers/Admin/OrdersController.php
+++ b/app/Http/Controllers/Admin/OrdersController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Models\Order;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use Exception;
 
 class OrdersController extends Controller
 {
@@ -40,17 +41,17 @@ class OrdersController extends Controller
         try {
             $validated = $request->validate([
                 'status' => 'required|in:paid,processing,shipped,cancelled',
-                'resi' => 'required_if:status,shipped|nullable|string|max:255',
+                'resi_code' => 'required_if:status,shipped|nullable|string|max:255',
             ]);
 
-            if ($request->status === 'shipped') {
-                if (empty($request->resi_code)) {
+            if ($validated['status'] === 'shipped') {
+                if (empty($validated['resi_code'])) {
                     throw new Exception('Resi number is required for shipped status.');
                 }
-                $order->resi_code = $request->resi_code;
+                $order->resi_code = $validated['resi_code'];
                 $order->save();
             }
-            $order->updateStatus($request->status);
+            $order->updateStatus($validated['status']);
             return redirect()->back()->with('success', 'Order status updated');
         } catch (Exception $e) {
             return redirect()->back()->with(['error' => $e->getMessage()]);


### PR DESCRIPTION
## Summary
- import `Exception`
- standardize `resi_code` usage and validation for shipped orders

## Testing
- `php -l app/Http/Controllers/Admin/OrdersController.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68baadd7ab6c8328b018d5c3aee9ccb2