### PR TITLE
Cast product image attribute as array

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -54,13 +54,13 @@ class ProductController extends Controller
                 'image' => 'required|image|mimes:jpeg,png,jpg|max:2048'
             ]);
 
-            $image = null;
+            $image = [];
             if ($request->hasFile('image')) {
                 $file = $request->file('image');
                 $content = file_get_contents($file->getRealPath());
                 $extension = $file->getClientOriginalExtension();
                 $base64 = base64_encode($content);
-                $image = "data:image/{$extension};base64,{$base64}";
+                $image[] = "data:image/{$extension};base64,{$base64}";
             }
 
             Product::create([
@@ -113,7 +113,7 @@ class ProductController extends Controller
                 $content = file_get_contents($file->getRealPath());
                 $extension = $file->getClientOriginalExtension();
                 $base64 = base64_encode($content);
-                $data['image'] = "data:image/{$extension};base64,{$base64}";
+                $data['image'] = array_merge($product->image ?? [], ["data:image/{$extension};base64,{$base64}"]);
             }
 
             $product->update($data);

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -25,7 +25,8 @@ class Product extends Model
     protected $casts = [
         'price' => 'decimal:2',
         'is_active' => 'boolean',
-        'stock' => 'integer'
+        'stock' => 'integer',
+        'image' => 'array',
     ];
 
     /**
@@ -51,11 +52,11 @@ class Product extends Model
      */
     public function getPrimaryImage()
     {
-        if (!$this->image) {
+        if (empty($this->image)) {
             return null;
         }
 
-        return is_array($this->image) ? $this->image[0] : $this->image;
+        return $this->image[0];
     }
 
     /**
@@ -65,7 +66,7 @@ class Product extends Model
      */
     public function getAllImages()
     {
-        return is_array($this->image) ? $this->image : [$this->image];
+        return $this->image ?? [];
     }
 
     /**


### PR DESCRIPTION
## Summary
- cast `image` attribute on `Product` model to array and adjust image accessors
- store product images as arrays when creating or updating products

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l app/Models/Product.php app/Http/Controllers/Admin/ProductController.php`


------
https://chatgpt.com/codex/tasks/task_e_68babc65c6cc83288242fcdac8cb5352