### PR TITLE
Group admin routes and remove duplicate checkout route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,60 +25,58 @@ Route::post('/auth/logout', [AuthController::class, 'logout'])->name('auth.logou
 
 Route::middleware(['auth'])->group(function () {
     Route::post('/checkout/process', [UserCheckoutController::class, 'process'])->name('checkout.process');
-
 });
 
-Route::prefix('categories')->group(function () {
-    Route::get('/', [CategoryController::class, 'index'])
-        ->name('admin.categories.index');
-    Route::post('/', [CategoryController::class, 'store'])
-        ->name('admin.categories.store');
-    Route::put('/{category}', [CategoryController::class, 'update'])
-        ->name('admin.categories.update');
-    Route::delete('/{category}', [CategoryController::class, 'destroy'])
-        ->name('admin.categories.destroy');
-});
+Route::middleware(['auth', 'can:admin'])->prefix('admin')->group(function () {
+    Route::get('/dashboard', function () {
+        return view('admin.dashboard');
+    })->name('admin.dashboard');
 
-Route::prefix('products')->group(function () {
-    Route::get('/', [ProductController::class, 'index'])
-        ->name('admin.products.index');
-    Route::post('/', [ProductController::class, 'store'])
-        ->name('admin.products.store');
-    Route::put('/{product}', [ProductController::class, 'update'])
-        ->name('admin.products.update');
-    Route::delete('/{product}', [ProductController::class, 'destroy'])
-        ->name('admin.products.destroy');
-});
+    Route::prefix('categories')->group(function () {
+        Route::get('/', [CategoryController::class, 'index'])
+            ->name('admin.categories.index');
+        Route::post('/', [CategoryController::class, 'store'])
+            ->name('admin.categories.store');
+        Route::put('/{category}', [CategoryController::class, 'update'])
+            ->name('admin.categories.update');
+        Route::delete('/{category}', [CategoryController::class, 'destroy'])
+            ->name('admin.categories.destroy');
+    });
 
-// Users Management
-Route::prefix('users')->group(function () {
-    Route::get('/', [UserController::class, 'index'])
-        ->name('admin.users.index');
-    Route::delete('/{user}', [UserController::class, 'destroy'])
-        ->name('admin.users.destroy');
-});
-// Order History
-Route::get('/history-order', [OrderHistoryController::class, 'index'])
-    ->name('admin.history.index');
+    Route::prefix('products')->group(function () {
+        Route::get('/', [ProductController::class, 'index'])
+            ->name('admin.products.index');
+        Route::post('/', [ProductController::class, 'store'])
+            ->name('admin.products.store');
+        Route::put('/{product}', [ProductController::class, 'update'])
+            ->name('admin.products.update');
+        Route::delete('/{product}', [ProductController::class, 'destroy'])
+            ->name('admin.products.destroy');
+    });
 
+    // Users Management
+    Route::prefix('users')->group(function () {
+        Route::get('/', [UserController::class, 'index'])
+            ->name('admin.users.index');
+        Route::delete('/{user}', [UserController::class, 'destroy'])
+            ->name('admin.users.destroy');
+    });
 
-// Order Routes
-Route::prefix('orders')->group(function () {
-    Route::get('/', [OrdersController::class, 'index'])
-        ->name('admin.orders.index');
-    Route::patch('/{order}/status', [OrdersController::class, 'updateStatus'])
-        ->name('admin.orders.update-status');
+    // Order History
+    Route::get('/history-order', [OrderHistoryController::class, 'index'])
+        ->name('admin.history.index');
+
+    // Order Routes
+    Route::prefix('orders')->group(function () {
+        Route::get('/', [OrdersController::class, 'index'])
+            ->name('admin.orders.index');
+        Route::patch('/{order}/status', [OrdersController::class, 'updateStatus'])
+            ->name('admin.orders.update-status');
+    });
 });
 
 Route::get('/search', function () {
     return view('search');
 });
-// Admin Routes
-Route::get('/admin/dashboard', function () {
-    return view('admin.dashboard');
-})->name('admin.dashboard');
 
-Route::get('/admin/products', [ProductController::class, "index"])->name('admin.products');
-
-Route::post('checkout/process', [UserCheckoutController::class, 'process'])->name('checkout.process'); 
 Route::post('payment/update-status', [UserCheckoutController::class, 'updateStatus'])->name('payment.update-status');


### PR DESCRIPTION
## Summary
- Group category, product, user, order, history, and dashboard routes under `Route::middleware(['auth', 'can:admin'])->prefix('admin')`
- Remove duplicate checkout route so only the authenticated version remains

## Testing
- `composer install --no-interaction` *(fails: curl error 56 while downloading from api.github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68babf8a68348328a6ed77958e3247e5