### PR TITLE
refactor: move traits to App\Traits namespace

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -3,7 +3,7 @@
 namespace App\Models;
 
 
-use App\HasSlug;
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\HasOrderStatus;
+use App\Traits\HasOrderStatus;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Facades\DB;

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-use App\HasSlug;
-use App\ProductInventory;
+use App\Traits\HasSlug;
+use App\Traits\ProductInventory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 

--- a/app/Traits/HasOrderStatus.php
+++ b/app/Traits/HasOrderStatus.php
@@ -1,5 +1,5 @@
 <?php
-namespace App;
+namespace App\Traits;
 
 use Exception;
 use Illuminate\Support\Facades\DB;

--- a/app/Traits/HasSlug.php
+++ b/app/Traits/HasSlug.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace App\Traits;
 
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;

--- a/app/Traits/ProductInventory.php
+++ b/app/Traits/ProductInventory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace App\Traits;
 
 use Exception;
 


### PR DESCRIPTION
## Summary
- move `HasSlug`, `HasOrderStatus`, and `ProductInventory` traits into `app/Traits`
- update namespaces and imports to `App\Traits`

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68babf973a5c8328bdc5be3e412dbe24