### PR TITLE
Add AuthServiceProvider with admin gate

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        $this->registerPolicies();
+
+        Gate::define('admin', fn ($user) => $user->isAdmin());
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];


### PR DESCRIPTION
## Summary
- create AuthServiceProvider to register `admin` authorization gate
- register AuthServiceProvider in application's provider list

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: CONNECT tunnel failed)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bb7cc7de2c83288c8ca14b7c295aba