### PR TITLE
Expose user data for cart

### DIFF
--- a/resources/views/layouts/layouts-landing.blade.php
+++ b/resources/views/layouts/layouts-landing.blade.php
@@ -6,10 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>@yield('title') - {{ config('app.name') }}</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @vite(['resources/css/app.css'])
 </head>
 
 <body class="min-h-screen bg-gray-50">
+    <div id="user-data" hidden
+        data-logged-in="{{ auth()->check() ? 'true' : 'false' }}"
+        @auth
+            data-name="{{ Auth::user()->name }}"
+            data-phone="{{ Auth::user()->phone }}"
+            data-address="{{ Auth::user()->address }}"
+        @endauth
+    ></div>
     <!-- Navigation -->
     <header class="bg-white shadow-sm fixed w-full top-0 z-50">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16">
@@ -192,6 +200,7 @@
             </div>
         </div>
     </footer>
+    @vite(['resources/js/app.js'])
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Inject hidden `#user-data` div with login state and profile details
- Move app script to footer so cart.js can detect user data

## Testing
- `./vendor/bin/phpunit` *(failed: No such file or directory)*
- `composer install` *(failed: GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9b5e7cd48328915e9a1668e99ddb