### PR TITLE
Align payment status update URL with backend route

### DIFF
--- a/resources/js/cart.js
+++ b/resources/js/cart.js
@@ -352,7 +352,7 @@ class ShoppingCart {
 
     async updateTransactionStatus(orderId, result, status) {
         try {
-            const response = await fetch('/payments/update-status', {
+            const response = await fetch('/payment/update-status', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- fix cart payment status fetch to use `/payment/update-status`

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: Failed to open vendor/autoload.php)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb9b99301c832895e64b87581b207e