### PR TITLE
Fix orders menu link for admin users

### DIFF
--- a/resources/views/layouts/layouts-landing.blade.php
+++ b/resources/views/layouts/layouts-landing.blade.php
@@ -102,10 +102,13 @@
                                         Dashboard
                                     </a>
                                 @endif
-                                <a href="/orders"
-                                    class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-emerald-600">
-                                    Orders
-                                </a>
+
+                                @if (Auth::user()->canManageOrders())
+                                    <a href="{{ route('admin.orders.index') }}"
+                                        class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-emerald-600">
+                                        Orders
+                                    </a>
+                                @endif
 
                                 <div class="border-t border-gray-100 my-1"></div>
 


### PR DESCRIPTION
## Summary
- update the authenticated user dropdown to only show the Orders entry to admins and link it to the admin orders route

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ec99346c8328a6cab6391a2a0203