### PR TITLE
Add profile dropdown to admin header

### DIFF
--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -1,11 +1,45 @@
+@php
+    $user = Auth::user();
+    $displayName = $user?->name ?? 'Guest User';
+@endphp
+
 <header class="bg-white border-bottom sticky-top">
-    <div class="d-flex align-items-center justify-content-between p-3">
+    <div class="d-flex align-items-center justify-content-between p-3 gap-3">
         <!-- Mobile Toggle Button -->
         <button id="sidebarToggle" class="btn d-lg-none">
             <i class="bi bi-list fs-4"></i>
         </button>
 
         <!-- Header Title -->
-        <h1 class="h5 mb-0">@yield('title', 'Dashboard')</h1>
+        <h1 class="h5 mb-0 flex-grow-1">@yield('title', 'Dashboard')</h1>
+
+        <!-- Profile Dropdown -->
+        <div class="dropdown ms-auto">
+            <button class="btn btn-light border d-flex align-items-center gap-2" type="button" id="profileDropdown"
+                data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="d-none d-md-inline fw-semibold text-nowrap">{{ $displayName }}</span>
+                <span class="bg-primary text-white rounded-circle d-inline-flex align-items-center justify-content-center"
+                    style="width: 36px; height: 36px;">
+                    <i class="bi bi-person-fill"></i>
+                </span>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end shadow" aria-labelledby="profileDropdown">
+                <li>
+                    <h6 class="dropdown-header">{{ $displayName }}</h6>
+                </li>
+                <li><a class="dropdown-item" href="#"><i class="bi bi-person me-2"></i>Profil</a></li>
+                <li><a class="dropdown-item" href="#"><i class="bi bi-gear me-2"></i>Pengaturan</a></li>
+                <li>
+                    <hr class="dropdown-divider">
+                </li>
+                <li>
+                    <form method="POST" action="{{ route('auth.logout') }}">
+                        @csrf
+                        <button type="submit" class="dropdown-item text-danger"><i
+                                class="bi bi-box-arrow-right me-2"></i>Keluar</button>
+                    </form>
+                </li>
+            </ul>
+        </div>
     </div>
 </header>


### PR DESCRIPTION
## Summary
- add a profile dropdown trigger with the signed-in user's name to the admin header
- provide quick links for profile-related actions and a logout form inside the dropdown

## Testing
- php artisan serve --host=0.0.0.0 --port=8000 *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68db3b2480d0832892c20e0061761d08